### PR TITLE
Implement signature items

### DIFF
--- a/src/ppx_field_repr.ml
+++ b/src/ppx_field_repr.ml
@@ -9,44 +9,56 @@ open Ast_builder.Default
 let namespace = "ppx_fields_repr"
 let raise_errorf ~loc fmt = Location.raise_errorf ~loc ("%s: " ^^ fmt) namespace
 
+let type_of_label record_type label =
+  let loc = label.pld_loc in
+  let field_type = label.pld_type
+  and mutable_flag =
+    match label.pld_mutable with
+    | Immutable -> [%type: Field_repr.immutable]
+    | Mutable -> [%type: Field_repr.mutable_]
+  in
+  [%type: ([%t record_type], [%t field_type], [%t mutable_flag]) Field_repr.t]
+
+(** [\[ (label_name, loc, type) \]] Raise an error if the declaration is not of
+    a record. *)
+let fields_of_type_declaration ~loc tdecl =
+  let tdecl = name_type_params_in_td tdecl in
+  let labels =
+    match tdecl.ptype_kind with
+    | Ptype_record x -> x
+    | Ptype_open | Ptype_variant _ | Ptype_abstract ->
+        raise_errorf ~loc "type must be a record declaration."
+  in
+  let record_type = core_type_of_type_declaration tdecl in
+  ListLabels.map labels ~f:(fun label ->
+      (label.pld_name, label.pld_loc, type_of_label record_type label))
+
 let str_type_decl ~loc ~path:_ (_, tdecls) =
   ListLabels.concat_map tdecls ~f:(fun tdecl ->
-      let tdecl = name_type_params_in_td tdecl in
-      let labels =
-        match tdecl.ptype_kind with
-        | Ptype_record x -> x
-        | Ptype_open | Ptype_variant _ | Ptype_abstract ->
-            raise_errorf ~loc "type must be a record declaration."
-      in
-      let record_type = core_type_of_type_declaration tdecl in
-      ListLabels.mapi labels ~f:(fun pos label ->
-          let field_name = label.pld_name.txt
-          and field_type = label.pld_type
-          and mutable_flag =
-            match label.pld_mutable with
-            | Immutable -> [%type: Field_repr.immutable]
-            | Mutable -> [%type: Field_repr.mutable_]
-          and loc = label.pld_loc in
-          let type_ =
-            [%type:
-              ( [%t record_type],
-                [%t field_type],
-                [%t mutable_flag] )
-              Field_repr.t]
-          in
-          let repr =
-            [%expr Field_repr.Obj.unsafe_field_of_index [%e eint ~loc pos]]
-          in
-          pstr_value ~loc Nonrecursive
-            [
-              value_binding ~loc ~pat:(pvar ~loc field_name)
-                ~expr:(pexp_constraint ~loc repr type_);
-            ]))
+      fields_of_type_declaration ~loc tdecl
+      |> ListLabels.mapi ~f:(fun pos (field_name, loc, type_) ->
+             let repr =
+               [%expr Field_repr.Obj.unsafe_field_of_index [%e eint ~loc pos]]
+             in
+             pstr_value ~loc Nonrecursive
+               [
+                 value_binding ~loc ~pat:(ppat_var ~loc field_name)
+                   ~expr:(pexp_constraint ~loc repr type_);
+               ]))
+
+let sig_type_decl ~loc ~path:_ (_, tdecls) =
+  ListLabels.concat_map tdecls ~f:(fun tdecl ->
+      fields_of_type_declaration ~loc tdecl
+      |> ListLabels.map ~f:(fun (name, loc, type_) ->
+             psig_value ~loc (value_description ~loc ~name ~type_ ~prim:[])))
 
 let () =
   let open Deriving in
   ignore
-    (add ~str_type_decl:(Generator.make Args.empty str_type_decl) "field_repr")
+    (add
+       ~str_type_decl:(Generator.make Args.empty str_type_decl)
+       ~sig_type_decl:(Generator.make Args.empty sig_type_decl)
+       "field_repr")
 
 (*————————————————————————————————————————————————————————————————————————————
    Copyright (c) 2021 Craig Ferguson <me@craigfe.io>

--- a/test/blackbox-tests/ppx_output.t/run.t
+++ b/test/blackbox-tests/ppx_output.t/run.t
@@ -36,3 +36,18 @@ With a mutable field:
                                                     Field_repr.t)
       let _ = m
     end[@@ocaml.doc "@inline"][@@merlin.hide ]
+
+In an interface file:
+
+  $ standalone -intf - <<END
+  > type t = { foo : int; bar : bool } [@@deriving field_repr]
+  > END
+  type t = {
+    foo: int ;
+    bar: bool }[@@deriving field_repr]
+  include
+    sig
+      [@@@ocaml.warning "-32"]
+      val foo : (t, int, Field_repr.immutable) Field_repr.t
+      val bar : (t, bool, Field_repr.immutable) Field_repr.t
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/unit-tests/main.ml
+++ b/test/unit-tests/main.ml
@@ -3,7 +3,13 @@ open Field_repr.O
 let check_int pos = Alcotest.(check ~pos int) ""
 let check_string pos = Alcotest.(check ~pos string) ""
 
-type t = { mutable foo : int; mutable bar : string } [@@deriving field_repr]
+module X : sig
+  type t = { mutable foo : int; mutable bar : string } [@@deriving field_repr]
+end = struct
+  type t = { mutable foo : int; mutable bar : string } [@@deriving field_repr]
+end
+
+open X
 
 let check =
   let testable =


### PR DESCRIPTION
The ppx might be used in a signature. We just need to generate value descriptions, eg:

```ocaml
val foo : (t, int) Field_repr.t
```